### PR TITLE
Token 2022

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,7 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
+ "spl-token-2022 0.7.0",
 ]
 
 [[package]]
@@ -4671,7 +4672,20 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-program-error",
+ "spl-program-error 0.3.0",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af92f74cd3b0fdfda59fef4b571a92123e4df0f67cc43f73163975d31118ef82"
+dependencies = [
+ "num-derive 0.3.3",
+ "num-traits",
+ "solana-program",
+ "spl-program-error-derive 0.2.0",
+ "thiserror",
 ]
 
 [[package]]
@@ -4683,8 +4697,19 @@ dependencies = [
  "num-derive 0.4.1",
  "num-traits",
  "solana-program",
- "spl-program-error-derive",
+ "spl-program-error-derive 0.3.1",
  "thiserror",
+]
+
+[[package]]
+name = "spl-program-error-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173f3cc506847882189b3a5b67299f617fed2f9730f122dd197b82e1e213dee5"
+dependencies = [
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4701,6 +4726,19 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82149a5a06b5f158d03904066375eaf0c8a2422557cc3d5a25d277260d9a3b16"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-program-error 0.2.0",
+ "spl-type-length-value 0.2.0",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
@@ -4709,8 +4747,8 @@ dependencies = [
  "solana-program",
  "spl-discriminator",
  "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
+ "spl-program-error 0.3.0",
+ "spl-type-length-value 0.3.0",
 ]
 
 [[package]]
@@ -4763,6 +4801,25 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b24ac5786a3fefbf59f5606312c61abf87b23154e7a717e5d18216fbea4711db"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.3.3",
+ "num-traits",
+ "num_enum 0.6.1",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-memo 3.0.1",
+ "spl-token 4.0.0",
+ "spl-transfer-hook-interface 0.1.0",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4abf34a65ba420584a0c35f3903f8d727d1f13ababbdc3f714c6b065a686e86"
@@ -4778,8 +4835,8 @@ dependencies = [
  "spl-pod",
  "spl-token 4.0.0",
  "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
- "spl-type-length-value",
+ "spl-transfer-hook-interface 0.3.0",
+ "spl-type-length-value 0.3.0",
  "thiserror",
 ]
 
@@ -4793,8 +4850,26 @@ dependencies = [
  "solana-program",
  "spl-discriminator",
  "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
+ "spl-program-error 0.3.0",
+ "spl-type-length-value 0.3.0",
+]
+
+[[package]]
+name = "spl-transfer-hook-interface"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a2326852adf88716fbac7f54cd6ee2c8a0b5a14ede24db3b4519c4ff13df04b"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.3.3",
+ "num-traits",
+ "num_enum 0.6.1",
+ "solana-program",
+ "spl-discriminator",
+ "spl-tlv-account-resolution 0.2.0",
+ "spl-type-length-value 0.2.0",
+ "thiserror",
 ]
 
 [[package]]
@@ -4808,9 +4883,21 @@ dependencies = [
  "solana-program",
  "spl-discriminator",
  "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution",
- "spl-type-length-value",
+ "spl-program-error 0.3.0",
+ "spl-tlv-account-resolution 0.4.0",
+ "spl-type-length-value 0.3.0",
+]
+
+[[package]]
+name = "spl-type-length-value"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d085f426b33b8365fb98383d1b8b3925e21bdfe579c851ceaa7f511dbec191"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-program-error 0.2.0",
 ]
 
 [[package]]
@@ -4823,7 +4910,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator",
  "spl-pod",
- "spl-program-error",
+ "spl-program-error 0.3.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ members = [
     "lang/syn",
     "spl",
 ]
+resolver = "2"

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -220,9 +220,52 @@ pub trait Owner {
     fn owner() -> Pubkey;
 }
 
+/// Defines a list of addresses expected to own an account.
+pub trait Owners {
+    fn owners() -> &'static [Pubkey];
+}
+
+/// Defines a trait for checking the owner of a program.
+pub trait CheckOwner {
+    fn check_owner(owner: &Pubkey) -> Result<()>;
+}
+
+impl<T: Owners> CheckOwner for T {
+    fn check_owner(owner: &Pubkey) -> Result<()> {
+        if !Self::owners().contains(owner) {
+            Err(
+                error::Error::from(error::ErrorCode::AccountOwnedByWrongProgram)
+                    .with_account_name(*owner),
+            )
+        } else {
+            Ok(())
+        }
+    }
+}
+
 /// Defines the id of a program.
 pub trait Id {
     fn id() -> Pubkey;
+}
+
+/// Defines the possible ids of a program.
+pub trait Ids {
+    fn ids() -> &'static [Pubkey];
+}
+
+/// Defines a trait for checking the id of a program.
+pub trait CheckId {
+    fn check_id(id: &Pubkey) -> Result<()>;
+}
+
+impl<T: Ids> CheckId for T {
+    fn check_id(id: &Pubkey) -> Result<()> {
+        if !Self::ids().contains(id) {
+            Err(error::Error::from(error::ErrorCode::InvalidProgramId).with_account_name(*id))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 /// Defines the Pubkey of an account.

--- a/lang/syn/src/codegen/accounts/__client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__client_accounts.rs
@@ -1,8 +1,8 @@
+use crate::codegen::accounts::make_unreal_accounts;
 use crate::{AccountField, AccountsStruct, Ty};
 use heck::SnakeCase;
 use quote::{format_ident, quote};
 use std::str::FromStr;
-use crate::codegen::accounts::make_unreal_accounts;
 
 // Generates the private `__client_accounts` mod implementation, containing
 // a generated struct mapping 1-1 to the `Accounts` struct, except with
@@ -13,8 +13,8 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
         "__client_accounts_{}",
         accs.ident.to_string().to_snake_case()
     )
-        .parse()
-        .unwrap();
+    .parse()
+    .unwrap();
 
     let account_struct_fields: Vec<proc_macro2::TokenStream> = accs
         .fields
@@ -29,7 +29,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                                 "#[doc = r#\"{}\"#]",
                                 docs_line
                             ))
-                                .unwrap()
+                            .unwrap()
                         })
                         .collect()
                 } else {
@@ -41,8 +41,8 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                     s.symbol.to_snake_case(),
                     unreal_accounts,
                 )
-                    .parse()
-                    .unwrap();
+                .parse()
+                .unwrap();
                 quote! {
                     #docs
                     pub #name: #symbol
@@ -57,7 +57,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                                 "#[doc = r#\"{}\"#]",
                                 docs_line
                             ))
-                                .unwrap()
+                            .unwrap()
                         })
                         .collect()
                 } else {
@@ -135,7 +135,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
         "#[doc = \" Generated client accounts for [`{}`].\"]",
         name
     ))
-        .unwrap();
+    .unwrap();
 
     let cbg_name = make_unreal_accounts(name);
 
@@ -160,7 +160,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
             pub struct #cbg_name {
                 #(#account_struct_fields),*
             }
-            
+
             pub type #name = #cbg_name;
 
             #[automatically_derived]
@@ -176,4 +176,3 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
         }
     }
 }
-

--- a/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
@@ -149,7 +149,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
             })
             .collect()
     };
-    
+
     let phantom_data = if account_struct_fields.is_empty() {
         quote! { phantom: std::marker::PhantomData<&'info ()> }
     } else {

--- a/lang/syn/src/codegen/accounts/mod.rs
+++ b/lang/syn/src/codegen/accounts/mod.rs
@@ -9,7 +9,6 @@ pub fn make_unreal_accounts(ident: &syn::Ident) -> syn::Ident {
     format_ident!("{}Accounts", ident)
 }
 
-
 mod __client_accounts;
 mod __cpi_client_accounts;
 mod constraints;

--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -1,11 +1,10 @@
-use std::str::FromStr;
+use crate::codegen::accounts::make_unreal_accounts;
 use crate::codegen::program::common::*;
 use crate::parser;
 use crate::Program;
 use heck::{CamelCase, SnakeCase};
 use quote::{format_ident, quote};
-use crate::codegen::accounts::make_unreal_accounts;
-
+use std::str::FromStr;
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     let ctor_variant = match &program.state {

--- a/lang/syn/src/parser/program/instructions.rs
+++ b/lang/syn/src/parser/program/instructions.rs
@@ -1,9 +1,9 @@
-use syn::Meta;
 use crate::parser::docs;
 use crate::parser::program::ctx_accounts_ident;
 use crate::{FallbackFn, Ix, IxArg, IxReturn};
 use syn::parse::{Error as ParseError, Result as ParseResult};
 use syn::spanned::Spanned;
+use syn::Meta;
 
 // Parse all non-state ix handlers from the program mod definition.
 pub fn parse(program_mod: &syn::ItemMod) -> ParseResult<(Vec<Ix>, Option<FallbackFn>)> {
@@ -28,12 +28,11 @@ pub fn parse(program_mod: &syn::ItemMod) -> ParseResult<(Vec<Ix>, Option<Fallbac
             let docs = docs::parse(&method.attrs);
             let returns = parse_return(method)?;
             let anchor_ident = ctx_accounts_ident(&ctx.raw_arg)?;
-            let needs_remaining_accounts = method.attrs.iter().any(|attr| {
-                match attr.parse_meta() {
+            let needs_remaining_accounts =
+                method.attrs.iter().any(|attr| match attr.parse_meta() {
                     Ok(Meta::Path(path)) => path.is_ident("remaining_accounts"),
                     _ => false,
-                }
-            });
+                });
             Ok(Ix {
                 needs_remaining_accounts,
                 raw_method: method.clone(),

--- a/lang/syn/src/parser/program/mod.rs
+++ b/lang/syn/src/parser/program/mod.rs
@@ -14,16 +14,14 @@ pub fn parse(mut program_mod: syn::ItemMod) -> ParseResult<Program> {
     program_mod.content.iter_mut().for_each(|(_, items)| {
         for item in items.iter_mut() {
             if let syn::Item::Fn(item_fn) = item {
-                item_fn.attrs.retain(|attr| {
-                    match attr.parse_meta() {
-                        Ok(syn::Meta::Path(path)) => !path.is_ident("remaining_accounts"),
-                        _ => true,
-                    }
+                item_fn.attrs.retain(|attr| match attr.parse_meta() {
+                    Ok(syn::Meta::Path(path)) => !path.is_ident("remaining_accounts"),
+                    _ => true,
                 });
             }
         }
     });
-    
+
     Ok(Program {
         state,
         ixs,

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -8,9 +8,11 @@ description = "CPI clients for SPL programs"
 publish = ["star-atlas"]
 
 [features]
-default = ["mint", "token", "associated_token"]
+default = ["mint", "token", "associated_token", "token_2022", "token_2022_extensions"]
 mint = []
 token = ["spl-token"]
+token_2022 = ["spl-token-2022"]
+token_2022_extensions = ["spl-token-2022"]
 associated_token = ["spl-associated-token-account"]
 governance = []
 shmem = []
@@ -25,3 +27,4 @@ serum_dex = { git = "https://github.com/project-serum/serum-dex", rev = "1be91f2
 solana-program = ">=1.10.29"
 spl-associated-token-account = { version = "1.1.0", features = ["no-entrypoint"], optional = true }
 spl-token = { version = "3.3.0", features = ["no-entrypoint"], optional = true }
+spl-token-2022 = { version = "0.7", features = ["no-entrypoint"], optional = true }

--- a/spl/src/associated_token.rs
+++ b/spl/src/associated_token.rs
@@ -3,7 +3,10 @@ use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;
 use anchor_lang::{context::CpiContext, Accounts};
 
-pub use spl_associated_token_account::{get_associated_token_address, ID};
+pub use spl_associated_token_account;
+pub use spl_associated_token_account::{
+    get_associated_token_address, get_associated_token_address_with_program_id, ID,
+};
 
 pub fn create<'info>(ctx: CpiContext<'_, '_, '_, 'info, Create<'info>>) -> Result<()> {
     let ix = spl_associated_token_account::instruction::create_associated_token_account(
@@ -21,7 +24,30 @@ pub fn create<'info>(ctx: CpiContext<'_, '_, '_, 'info, Create<'info>>) -> Resul
             ctx.accounts.mint,
             ctx.accounts.system_program,
             ctx.accounts.token_program,
-            ctx.accounts.rent,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn create_idempotent<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, CreateIdempotent<'info>>,
+) -> Result<()> {
+    let ix = spl_associated_token_account::instruction::create_associated_token_account_idempotent(
+        ctx.accounts.payer.key,
+        ctx.accounts.authority.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.token_program.key,
+    );
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.payer,
+            ctx.accounts.associated_token,
+            ctx.accounts.authority,
+            ctx.accounts.mint,
+            ctx.accounts.system_program,
+            ctx.accounts.token_program,
         ],
         ctx.signer_seeds,
     )
@@ -36,8 +62,9 @@ pub struct Create<'info> {
     pub mint: AccountInfo<'info>,
     pub system_program: AccountInfo<'info>,
     pub token_program: AccountInfo<'info>,
-    pub rent: AccountInfo<'info>,
 }
+
+type CreateIdempotent<'info> = Create<'info>;
 
 #[derive(Clone)]
 pub struct AssociatedToken;

--- a/spl/src/lib.rs
+++ b/spl/src/lib.rs
@@ -9,6 +9,15 @@ pub mod mint;
 #[cfg(feature = "token")]
 pub mod token;
 
+#[cfg(feature = "token_2022")]
+pub mod token_2022;
+
+#[cfg(feature = "token_2022_extensions")]
+pub mod token_2022_extensions;
+
+#[cfg(feature = "token_2022")]
+pub mod token_interface;
+
 #[cfg(feature = "dex")]
 pub mod dex;
 

--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -33,6 +33,34 @@ pub fn transfer<'info>(
     .map_err(Into::into)
 }
 
+pub fn transfer_checked<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, TransferChecked<'info>>,
+    amount: u64,
+    decimals: u8,
+) -> Result<()> {
+    let ix = spl_token::instruction::transfer_checked(
+        &spl_token::ID,
+        ctx.accounts.from.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.to.key,
+        ctx.accounts.authority.key,
+        &[],
+        amount,
+        decimals,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.from,
+            ctx.accounts.mint,
+            ctx.accounts.to,
+            ctx.accounts.authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
 pub fn mint_to<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, MintTo<'info>>,
     amount: u64,
@@ -102,6 +130,34 @@ pub fn approve<'info>(
     .map_err(Into::into)
 }
 
+pub fn approve_checked<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, ApproveChecked<'info>>,
+    amount: u64,
+    decimals: u8,
+) -> Result<()> {
+    let ix = spl_token::instruction::approve_checked(
+        &spl_token::ID,
+        ctx.accounts.to.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.delegate.key,
+        ctx.accounts.authority.key,
+        &[],
+        amount,
+        decimals,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.to,
+            ctx.accounts.mint,
+            ctx.accounts.delegate,
+            ctx.accounts.authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
 pub fn revoke<'info>(ctx: CpiContext<'_, '_, '_, 'info, Revoke<'info>>) -> Result<()> {
     let ix = spl_token::instruction::revoke(
         &spl_token::ID,
@@ -134,6 +190,23 @@ pub fn initialize_account<'info>(
             ctx.accounts.authority.clone(),
             ctx.accounts.rent.clone(),
         ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn initialize_account3<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeAccount3<'info>>,
+) -> Result<()> {
+    let ix = spl_token::instruction::initialize_account3(
+        &spl_token::ID,
+        ctx.accounts.account.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.authority.key,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.account, ctx.accounts.mint],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -222,6 +295,23 @@ pub fn initialize_mint<'info>(
     .map_err(Into::into)
 }
 
+pub fn initialize_mint2<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeMint2<'info>>,
+    decimals: u8,
+    authority: &Pubkey,
+    freeze_authority: Option<&Pubkey>,
+) -> Result<()> {
+    let ix = spl_token::instruction::initialize_mint2(
+        &spl_token::ID,
+        ctx.accounts.mint.key,
+        authority,
+        freeze_authority,
+        decimals,
+    )?;
+    solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
+        .map_err(Into::into)
+}
+
 pub fn set_authority<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, SetAuthority<'info>>,
     authority_type: spl_token::instruction::AuthorityType,
@@ -265,6 +355,14 @@ pub struct Transfer<'info> {
 }
 
 #[derive(Accounts)]
+pub struct TransferChecked<'info> {
+    pub from: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub to: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
 pub struct MintTo<'info> {
     pub mint: AccountInfo<'info>,
     pub to: AccountInfo<'info>,
@@ -286,6 +384,14 @@ pub struct Approve<'info> {
 }
 
 #[derive(Accounts)]
+pub struct ApproveChecked<'info> {
+    pub to: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub delegate: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
 pub struct Revoke<'info> {
     pub source: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
@@ -297,6 +403,13 @@ pub struct InitializeAccount<'info> {
     pub mint: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
     pub rent: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct InitializeAccount3<'info> {
+    pub account: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]
@@ -324,6 +437,11 @@ pub struct ThawAccount<'info> {
 pub struct InitializeMint<'info> {
     pub mint: AccountInfo<'info>,
     pub rent: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct InitializeMint2<'info> {
+    pub mint: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]

--- a/spl/src/token_2022.rs
+++ b/spl/src/token_2022.rs
@@ -1,0 +1,593 @@
+use anchor_lang::solana_program::account_info::AccountInfo;
+use anchor_lang::solana_program::pubkey::Pubkey;
+use anchor_lang::Result;
+use anchor_lang::{context::CpiContext, Accounts};
+
+pub use spl_token_2022;
+pub use spl_token_2022::ID;
+
+pub fn transfer_checked<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, TransferChecked<'info>>,
+    amount: u64,
+    decimals: u8,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::transfer_checked(
+        ctx.program.key,
+        ctx.accounts.from.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.to.key,
+        ctx.accounts.authority.key,
+        &[],
+        amount,
+        decimals,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.from,
+            ctx.accounts.mint,
+            ctx.accounts.to,
+            ctx.accounts.authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn mint_to<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, MintTo<'info>>,
+    amount: u64,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::mint_to(
+        ctx.program.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.to.key,
+        ctx.accounts.authority.key,
+        &[],
+        amount,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.to, ctx.accounts.mint, ctx.accounts.authority],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn mint_to_checked<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, MintToChecked<'info>>,
+    amount: u64,
+    decimals: u8,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::mint_to_checked(
+        ctx.program.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.to.key,
+        ctx.accounts.authority.key,
+        &[],
+        amount,
+        decimals,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.to, ctx.accounts.mint, ctx.accounts.authority],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn burn<'info>(ctx: CpiContext<'_, '_, '_, 'info, Burn<'info>>, amount: u64) -> Result<()> {
+    let ix = spl_token_2022::instruction::burn(
+        ctx.program.key,
+        ctx.accounts.from.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.authority.key,
+        &[],
+        amount,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.from, ctx.accounts.mint, ctx.accounts.authority],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn burn_checked<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, BurnChecked<'info>>,
+    amount: u64,
+    decimals: u8,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::burn_checked(
+        ctx.program.key,
+        ctx.accounts.from.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.authority.key,
+        &[],
+        amount,
+        decimals,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.from, ctx.accounts.mint, ctx.accounts.authority],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn approve<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, Approve<'info>>,
+    amount: u64,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::approve(
+        ctx.program.key,
+        ctx.accounts.to.key,
+        ctx.accounts.delegate.key,
+        ctx.accounts.authority.key,
+        &[],
+        amount,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.to,
+            ctx.accounts.delegate,
+            ctx.accounts.authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn approve_checked<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, ApproveChecked<'info>>,
+    amount: u64,
+    decimals: u8,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::approve_checked(
+        ctx.program.key,
+        ctx.accounts.to.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.delegate.key,
+        ctx.accounts.authority.key,
+        &[],
+        amount,
+        decimals,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.to,
+            ctx.accounts.mint,
+            ctx.accounts.delegate,
+            ctx.accounts.authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn revoke<'info>(ctx: CpiContext<'_, '_, '_, 'info, Revoke<'info>>) -> Result<()> {
+    let ix = spl_token_2022::instruction::revoke(
+        ctx.program.key,
+        ctx.accounts.source.key,
+        ctx.accounts.authority.key,
+        &[],
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.source, ctx.accounts.authority],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn initialize_account<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeAccount<'info>>,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::initialize_account(
+        ctx.program.key,
+        ctx.accounts.account.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.authority.key,
+    )?;
+    solana_program::program::invoke(
+        &ix,
+        &[
+            ctx.accounts.account,
+            ctx.accounts.mint,
+            ctx.accounts.authority,
+            ctx.accounts.rent,
+        ],
+    )
+    .map_err(Into::into)
+}
+
+pub fn initialize_account3<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeAccount3<'info>>,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::initialize_account3(
+        ctx.program.key,
+        ctx.accounts.account.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.authority.key,
+    )?;
+    solana_program::program::invoke(&ix, &[ctx.accounts.account, ctx.accounts.mint])
+        .map_err(Into::into)
+}
+
+pub fn close_account<'info>(ctx: CpiContext<'_, '_, '_, 'info, CloseAccount<'info>>) -> Result<()> {
+    let ix = spl_token_2022::instruction::close_account(
+        ctx.program.key,
+        ctx.accounts.account.key,
+        ctx.accounts.destination.key,
+        ctx.accounts.authority.key,
+        &[], // TODO: support multisig
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.account,
+            ctx.accounts.destination,
+            ctx.accounts.authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn freeze_account<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, FreezeAccount<'info>>,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::freeze_account(
+        ctx.program.key,
+        ctx.accounts.account.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.authority.key,
+        &[], // TODO: Support multisig signers.
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.account,
+            ctx.accounts.mint,
+            ctx.accounts.authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn thaw_account<'info>(ctx: CpiContext<'_, '_, '_, 'info, ThawAccount<'info>>) -> Result<()> {
+    let ix = spl_token_2022::instruction::thaw_account(
+        ctx.program.key,
+        ctx.accounts.account.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.authority.key,
+        &[], // TODO: Support multisig signers.
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.account,
+            ctx.accounts.mint,
+            ctx.accounts.authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn initialize_mint<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeMint<'info>>,
+    decimals: u8,
+    authority: &Pubkey,
+    freeze_authority: Option<&Pubkey>,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::initialize_mint(
+        ctx.program.key,
+        ctx.accounts.mint.key,
+        authority,
+        freeze_authority,
+        decimals,
+    )?;
+    solana_program::program::invoke(&ix, &[ctx.accounts.mint, ctx.accounts.rent])
+        .map_err(Into::into)
+}
+
+pub fn initialize_mint2<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeMint2<'info>>,
+    decimals: u8,
+    authority: &Pubkey,
+    freeze_authority: Option<&Pubkey>,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::initialize_mint2(
+        ctx.program.key,
+        ctx.accounts.mint.key,
+        authority,
+        freeze_authority,
+        decimals,
+    )?;
+    solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
+}
+
+pub fn set_authority<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, SetAuthority<'info>>,
+    authority_type: spl_token_2022::instruction::AuthorityType,
+    new_authority: Option<Pubkey>,
+) -> Result<()> {
+    let mut spl_new_authority: Option<&Pubkey> = None;
+    if new_authority.is_some() {
+        spl_new_authority = new_authority.as_ref()
+    }
+
+    let ix = spl_token_2022::instruction::set_authority(
+        ctx.program.key,
+        ctx.accounts.account_or_mint.key,
+        spl_new_authority,
+        authority_type,
+        ctx.accounts.current_authority.key,
+        &[], // TODO: Support multisig signers.
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.account_or_mint, ctx.accounts.current_authority],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn sync_native<'info>(ctx: CpiContext<'_, '_, '_, 'info, SyncNative<'info>>) -> Result<()> {
+    let ix = spl_token_2022::instruction::sync_native(ctx.program.key, ctx.accounts.account.key)?;
+    solana_program::program::invoke(&ix, &[ctx.accounts.account]).map_err(Into::into)
+}
+
+pub fn get_account_data_size<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, GetAccountDataSize<'info>>,
+    extension_types: &[spl_token_2022::extension::ExtensionType],
+) -> Result<u64> {
+    let ix = spl_token_2022::instruction::get_account_data_size(
+        ctx.program.key,
+        ctx.accounts.mint.key,
+        extension_types,
+    )?;
+    solana_program::program::invoke(&ix, &[ctx.accounts.mint])?;
+    solana_program::program::get_return_data()
+        .ok_or(solana_program::program_error::ProgramError::InvalidInstructionData)
+        .and_then(|(key, data)| {
+            if key != *ctx.program.key {
+                Err(solana_program::program_error::ProgramError::IncorrectProgramId)
+            } else {
+                data.try_into().map(u64::from_le_bytes).map_err(|_| {
+                    solana_program::program_error::ProgramError::InvalidInstructionData
+                })
+            }
+        })
+        .map_err(Into::into)
+}
+
+pub fn initialize_mint_close_authority<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeMintCloseAuthority<'info>>,
+    close_authority: Option<&Pubkey>,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::initialize_mint_close_authority(
+        ctx.program.key,
+        ctx.accounts.mint.key,
+        close_authority,
+    )?;
+    solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
+}
+
+pub fn initialize_immutable_owner<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeImmutableOwner<'info>>,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::initialize_immutable_owner(
+        ctx.program.key,
+        ctx.accounts.account.key,
+    )?;
+    solana_program::program::invoke(&ix, &[ctx.accounts.account]).map_err(Into::into)
+}
+
+pub fn amount_to_ui_amount<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, AmountToUiAmount<'info>>,
+    amount: u64,
+) -> Result<String> {
+    let ix = spl_token_2022::instruction::amount_to_ui_amount(
+        ctx.program.key,
+        ctx.accounts.account.key,
+        amount,
+    )?;
+    solana_program::program::invoke(&ix, &[ctx.accounts.account])?;
+    solana_program::program::get_return_data()
+        .ok_or(solana_program::program_error::ProgramError::InvalidInstructionData)
+        .and_then(|(key, data)| {
+            if key != *ctx.program.key {
+                Err(solana_program::program_error::ProgramError::IncorrectProgramId)
+            } else {
+                String::from_utf8(data).map_err(|_| {
+                    solana_program::program_error::ProgramError::InvalidInstructionData
+                })
+            }
+        })
+        .map_err(Into::into)
+}
+
+pub fn ui_amount_to_amount<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, UiAmountToAmount<'info>>,
+    ui_amount: &str,
+) -> Result<u64> {
+    let ix = spl_token_2022::instruction::ui_amount_to_amount(
+        ctx.program.key,
+        ctx.accounts.account.key,
+        ui_amount,
+    )?;
+    solana_program::program::invoke(&ix, &[ctx.accounts.account])?;
+    solana_program::program::get_return_data()
+        .ok_or(solana_program::program_error::ProgramError::InvalidInstructionData)
+        .and_then(|(key, data)| {
+            if key != *ctx.program.key {
+                Err(solana_program::program_error::ProgramError::IncorrectProgramId)
+            } else {
+                data.try_into().map(u64::from_le_bytes).map_err(|_| {
+                    solana_program::program_error::ProgramError::InvalidInstructionData
+                })
+            }
+        })
+        .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct Transfer<'info> {
+    pub from: AccountInfo<'info>,
+    pub to: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct TransferChecked<'info> {
+    pub from: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub to: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct MintTo<'info> {
+    pub mint: AccountInfo<'info>,
+    pub to: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct MintToChecked<'info> {
+    pub mint: AccountInfo<'info>,
+    pub to: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct Burn<'info> {
+    pub mint: AccountInfo<'info>,
+    pub from: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct BurnChecked<'info> {
+    pub mint: AccountInfo<'info>,
+    pub from: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct Approve<'info> {
+    pub to: AccountInfo<'info>,
+    pub delegate: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct ApproveChecked<'info> {
+    pub to: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub delegate: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct Revoke<'info> {
+    pub source: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct InitializeAccount<'info> {
+    pub account: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+    pub rent: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct InitializeAccount3<'info> {
+    pub account: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct CloseAccount<'info> {
+    pub account: AccountInfo<'info>,
+    pub destination: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct FreezeAccount<'info> {
+    pub account: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct ThawAccount<'info> {
+    pub account: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct InitializeMint<'info> {
+    pub mint: AccountInfo<'info>,
+    pub rent: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct InitializeMint2<'info> {
+    pub mint: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct SetAuthority<'info> {
+    pub current_authority: AccountInfo<'info>,
+    pub account_or_mint: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct SyncNative<'info> {
+    pub account: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct GetAccountDataSize<'info> {
+    pub mint: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct InitializeMintCloseAuthority<'info> {
+    pub mint: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct InitializeImmutableOwner<'info> {
+    pub account: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct AmountToUiAmount<'info> {
+    pub account: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct UiAmountToAmount<'info> {
+    pub account: AccountInfo<'info>,
+}
+
+#[derive(Clone)]
+pub struct Token2022;
+
+impl anchor_lang::Id for Token2022 {
+    fn id() -> Pubkey {
+        ID
+    }
+}

--- a/spl/src/token_2022_extensions/confidential_transfer.rs
+++ b/spl/src/token_2022_extensions/confidential_transfer.rs
@@ -1,0 +1,1 @@
+// waiting for labs to merge

--- a/spl/src/token_2022_extensions/confidential_transfer_fee.rs
+++ b/spl/src/token_2022_extensions/confidential_transfer_fee.rs
@@ -1,0 +1,1 @@
+// waiting for labs to merge

--- a/spl/src/token_2022_extensions/cpi_guard.rs
+++ b/spl/src/token_2022_extensions/cpi_guard.rs
@@ -1,0 +1,49 @@
+use anchor_lang::Result;
+use anchor_lang::{context::CpiContext, Accounts};
+use solana_program::account_info::AccountInfo;
+
+pub fn cpi_guard_enable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'info>>) -> Result<()> {
+    let ix = spl_token_2022::extension::cpi_guard::instruction::enable_cpi_guard(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.account.key,
+        ctx.accounts.account.owner,
+        &[],
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.token_program_id,
+            ctx.accounts.account,
+            ctx.accounts.owner,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn cpi_guard_disable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'info>>) -> Result<()> {
+    let ix = spl_token_2022::extension::cpi_guard::instruction::disable_cpi_guard(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.account.key,
+        ctx.accounts.account.owner,
+        &[],
+    )?;
+
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.token_program_id,
+            ctx.accounts.account,
+            ctx.accounts.owner,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct CpiGuard<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub account: AccountInfo<'info>,
+    pub owner: AccountInfo<'info>,
+}

--- a/spl/src/token_2022_extensions/default_account_state.rs
+++ b/spl/src/token_2022_extensions/default_account_state.rs
@@ -1,0 +1,58 @@
+use anchor_lang::Result;
+use anchor_lang::{context::CpiContext, Accounts};
+use solana_program::account_info::AccountInfo;
+use spl_token_2022::state::AccountState;
+
+pub fn default_account_state_initialize<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, DefaultAccountStateInitialize<'info>>,
+    state: &AccountState,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::default_account_state::instruction::initialize_default_account_state(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        state
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.token_program_id, ctx.accounts.mint],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct DefaultAccountStateInitialize<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn default_account_state_update<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, DefaultAccountStateUpdate<'info>>,
+    state: &AccountState,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::default_account_state::instruction::update_default_account_state(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.freeze_authority.key,
+        &[],
+        state
+    )?;
+
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.token_program_id,
+            ctx.accounts.mint,
+            ctx.accounts.freeze_authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct DefaultAccountStateUpdate<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub freeze_authority: AccountInfo<'info>,
+}

--- a/spl/src/token_2022_extensions/immutable_owner.rs
+++ b/spl/src/token_2022_extensions/immutable_owner.rs
@@ -1,0 +1,24 @@
+use anchor_lang::Result;
+use anchor_lang::{context::CpiContext, Accounts};
+use solana_program::account_info::AccountInfo;
+
+pub fn immutable_owner_initialize<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, ImmutableOwnerInitialize<'info>>,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::initialize_immutable_owner(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.token_account.key,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.token_program_id, ctx.accounts.token_account],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct ImmutableOwnerInitialize<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub token_account: AccountInfo<'info>,
+}

--- a/spl/src/token_2022_extensions/interest_bearing_mint.rs
+++ b/spl/src/token_2022_extensions/interest_bearing_mint.rs
@@ -1,0 +1,59 @@
+use anchor_lang::Result;
+use anchor_lang::{context::CpiContext, Accounts};
+use solana_program::account_info::AccountInfo;
+use solana_program::pubkey::Pubkey;
+
+pub fn interest_bearing_mint_initialize<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InterestBearingMintInitialize<'info>>,
+    rate_authority: Option<Pubkey>,
+    rate: i16,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::interest_bearing_mint::instruction::initialize(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        rate_authority,
+        rate,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.token_program_id, ctx.accounts.mint],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct InterestBearingMintInitialize<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn interest_bearing_mint_update_rate<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InterestBearingMintUpdateRate<'info>>,
+    rate: i16,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::interest_bearing_mint::instruction::update_rate(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.rate_authority.key,
+        &[],
+        rate,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.token_program_id,
+            ctx.accounts.mint,
+            ctx.accounts.rate_authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct InterestBearingMintUpdateRate<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub rate_authority: AccountInfo<'info>,
+}

--- a/spl/src/token_2022_extensions/memo_transfer.rs
+++ b/spl/src/token_2022_extensions/memo_transfer.rs
@@ -1,0 +1,53 @@
+use anchor_lang::Result;
+use anchor_lang::{context::CpiContext, Accounts};
+use solana_program::account_info::AccountInfo;
+
+pub fn memo_transfer_initialize<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, MemoTransfer<'info>>,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::memo_transfer::instruction::enable_required_transfer_memos(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.account.key,
+        ctx.accounts.owner.key,
+        &[],
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.token_program_id,
+            ctx.accounts.account,
+            ctx.accounts.owner,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+pub fn memo_transfer_disable<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, MemoTransfer<'info>>,
+) -> Result<()> {
+    let ix =
+        spl_token_2022::extension::memo_transfer::instruction::disable_required_transfer_memos(
+            ctx.accounts.token_program_id.key,
+            ctx.accounts.account.key,
+            ctx.accounts.owner.key,
+            &[],
+        )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.token_program_id,
+            ctx.accounts.account,
+            ctx.accounts.owner,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct MemoTransfer<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub account: AccountInfo<'info>,
+    pub owner: AccountInfo<'info>,
+}

--- a/spl/src/token_2022_extensions/metadata_pointer.rs
+++ b/spl/src/token_2022_extensions/metadata_pointer.rs
@@ -1,0 +1,29 @@
+use anchor_lang::solana_program::account_info::AccountInfo;
+use anchor_lang::solana_program::pubkey::Pubkey;
+use anchor_lang::Result;
+use anchor_lang::{context::CpiContext, Accounts};
+
+pub fn metadata_pointer_initialize<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, MetadataPointerInitialize<'info>>,
+    authority: Option<Pubkey>,
+    metadata_address: Option<Pubkey>,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::metadata_pointer::instruction::initialize(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        authority,
+        metadata_address,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.token_program_id, ctx.accounts.mint],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct MetadataPointerInitialize<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+}

--- a/spl/src/token_2022_extensions/mint_close_authority.rs
+++ b/spl/src/token_2022_extensions/mint_close_authority.rs
@@ -1,0 +1,27 @@
+use anchor_lang::solana_program::account_info::AccountInfo;
+use anchor_lang::solana_program::pubkey::Pubkey;
+use anchor_lang::Result;
+use anchor_lang::{context::CpiContext, Accounts};
+
+pub fn mint_close_authority_initialize<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, MintCloseAuthorityInitialize<'info>>,
+    authority: Option<&Pubkey>,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::initialize_mint_close_authority(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        authority,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.token_program_id, ctx.accounts.mint],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct MintCloseAuthorityInitialize<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+}

--- a/spl/src/token_2022_extensions/mod.rs
+++ b/spl/src/token_2022_extensions/mod.rs
@@ -1,0 +1,25 @@
+pub mod confidential_transfer;
+pub mod confidential_transfer_fee;
+pub mod cpi_guard;
+pub mod default_account_state;
+pub mod immutable_owner;
+pub mod interest_bearing_mint;
+pub mod memo_transfer;
+pub mod metadata_pointer;
+pub mod mint_close_authority;
+pub mod non_transferable;
+pub mod permanent_delegate;
+pub mod transfer_fee;
+pub mod transfer_hook;
+
+pub use cpi_guard::*;
+pub use default_account_state::*;
+pub use immutable_owner::*;
+pub use interest_bearing_mint::*;
+pub use memo_transfer::*;
+pub use metadata_pointer::*;
+pub use mint_close_authority::*;
+pub use non_transferable::*;
+pub use permanent_delegate::*;
+pub use transfer_fee::*;
+pub use transfer_hook::*;

--- a/spl/src/token_2022_extensions/non_transferable.rs
+++ b/spl/src/token_2022_extensions/non_transferable.rs
@@ -1,0 +1,24 @@
+use anchor_lang::Result;
+use anchor_lang::{context::CpiContext, Accounts};
+use solana_program::account_info::AccountInfo;
+
+pub fn non_transferable_mint_initialize<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, NonTransferableMintInitialize<'info>>,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::initialize_non_transferable_mint(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.token_program_id, ctx.accounts.mint],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct NonTransferableMintInitialize<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+}

--- a/spl/src/token_2022_extensions/permanent_delegate.rs
+++ b/spl/src/token_2022_extensions/permanent_delegate.rs
@@ -1,0 +1,27 @@
+use anchor_lang::Result;
+use anchor_lang::{context::CpiContext, Accounts};
+use solana_program::account_info::AccountInfo;
+use solana_program::pubkey::Pubkey;
+
+pub fn permanent_delegate_initialize<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, PermanentDelegateInitialize<'info>>,
+    permanent_delegate: &Pubkey,
+) -> Result<()> {
+    let ix = spl_token_2022::instruction::initialize_permanent_delegate(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        permanent_delegate,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.token_program_id, ctx.accounts.mint],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct PermanentDelegateInitialize<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+}

--- a/spl/src/token_2022_extensions/transfer_fee.rs
+++ b/spl/src/token_2022_extensions/transfer_fee.rs
@@ -1,0 +1,193 @@
+use anchor_lang::Result;
+use anchor_lang::{context::CpiContext, Accounts};
+use solana_program::account_info::AccountInfo;
+use solana_program::pubkey::Pubkey;
+
+pub fn transfer_fee_initialize<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, TransferFeeInitialize<'info>>,
+    transfer_fee_config_authority: Option<&Pubkey>,
+    withdraw_withheld_authority: Option<&Pubkey>,
+    transfer_fee_basis_points: u16,
+    maximum_fee: u64,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::transfer_fee::instruction::initialize_transfer_fee_config(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        transfer_fee_config_authority,
+        withdraw_withheld_authority,
+        transfer_fee_basis_points,
+        maximum_fee,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.token_program_id, ctx.accounts.mint],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct TransferFeeInitialize<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn transfer_fee_set<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, TransferFeeSetTransferFee<'info>>,
+    transfer_fee_basis_points: u16,
+    maximum_fee: u64,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::transfer_fee::instruction::set_transfer_fee(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.authority.key,
+        &[],
+        transfer_fee_basis_points,
+        maximum_fee,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.token_program_id,
+            ctx.accounts.mint,
+            ctx.accounts.authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct TransferFeeSetTransferFee<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+pub fn transfer_checked_with_fee<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, TransferCheckedWithFee<'info>>,
+    amount: u64,
+    decimals: u8,
+    fee: u64,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::transfer_fee::instruction::transfer_checked_with_fee(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.source.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.destination.key,
+        ctx.accounts.authority.key,
+        &[],
+        amount,
+        decimals,
+        fee,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.token_program_id,
+            ctx.accounts.source,
+            ctx.accounts.mint,
+            ctx.accounts.destination,
+            ctx.accounts.authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct TransferCheckedWithFee<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub source: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub destination: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+pub fn harvest_withheld_tokens_to_mint<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, HarvestWithheldTokensToMint<'info>>,
+    sources: Vec<AccountInfo<'info>>,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::transfer_fee::instruction::harvest_withheld_tokens_to_mint(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        sources.iter().map(|a| a.key).collect::<Vec<_>>().as_slice(),
+    )?;
+
+    let mut account_infos = vec![ctx.accounts.token_program_id, ctx.accounts.mint];
+    account_infos.extend_from_slice(&sources);
+
+    solana_program::program::invoke_signed(&ix, &account_infos, ctx.signer_seeds)
+        .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct HarvestWithheldTokensToMint<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn withdraw_withheld_tokens_from_mint<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, WithdrawWithheldTokensFromMint<'info>>,
+) -> Result<()> {
+    let ix =
+        spl_token_2022::extension::transfer_fee::instruction::withdraw_withheld_tokens_from_mint(
+            ctx.accounts.token_program_id.key,
+            ctx.accounts.mint.key,
+            ctx.accounts.destination.key,
+            ctx.accounts.authority.key,
+            &[],
+        )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.token_program_id,
+            ctx.accounts.mint,
+            ctx.accounts.destination,
+            ctx.accounts.authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct WithdrawWithheldTokensFromMint<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub destination: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}
+
+pub fn withdraw_withheld_tokens_from_accounts<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, WithdrawWithheldTokensFromAccounts<'info>>,
+    sources: Vec<AccountInfo<'info>>,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::transfer_fee::instruction::withdraw_withheld_tokens_from_accounts(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.destination.key,
+        ctx.accounts.authority.key,
+        &[],
+        sources.iter().map(|a| a.key).collect::<Vec<_>>().as_slice(),
+    )?;
+
+    let mut account_infos = vec![
+        ctx.accounts.token_program_id,
+        ctx.accounts.mint,
+        ctx.accounts.destination,
+        ctx.accounts.authority,
+    ];
+    account_infos.extend_from_slice(&sources);
+
+    solana_program::program::invoke_signed(&ix, &account_infos, ctx.signer_seeds)
+        .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct WithdrawWithheldTokensFromAccounts<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub destination: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}

--- a/spl/src/token_2022_extensions/transfer_hook.rs
+++ b/spl/src/token_2022_extensions/transfer_hook.rs
@@ -1,0 +1,59 @@
+use anchor_lang::Result;
+use anchor_lang::{context::CpiContext, Accounts};
+use solana_program::account_info::AccountInfo;
+use solana_program::pubkey::Pubkey;
+
+pub fn transfer_hook_initialize<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, TransferHookInitialize<'info>>,
+    authority: Option<Pubkey>,
+    transfer_hook_program_id: Option<Pubkey>,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::transfer_hook::instruction::initialize(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        authority,
+        transfer_hook_program_id,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.token_program_id, ctx.accounts.mint],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct TransferHookInitialize<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn transfer_hook_update<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, TransferHookUpdate<'info>>,
+    transfer_hook_program_id: Option<Pubkey>,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::transfer_hook::instruction::update(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.authority.key,
+        &[],
+        transfer_hook_program_id,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.token_program_id,
+            ctx.accounts.mint,
+            ctx.accounts.authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct TransferHookUpdate<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}

--- a/spl/src/token_interface.rs
+++ b/spl/src/token_interface.rs
@@ -1,0 +1,96 @@
+use anchor_lang::solana_program::program_pack::Pack;
+use anchor_lang::solana_program::pubkey::Pubkey;
+use spl_token_2022::{
+    extension::{BaseStateWithExtensions, Extension, StateWithExtensions, ExtensionType},
+    solana_zk_token_sdk::instruction::Pod,
+};
+use std::ops::Deref;
+
+pub use crate::token_2022::*;
+
+static IDS: [Pubkey; 2] = [spl_token::ID, spl_token_2022::ID];
+
+#[derive(Clone, Debug, Default, PartialEq, Copy)]
+pub struct TokenAccount(spl_token_2022::state::Account);
+
+impl anchor_lang::AccountDeserialize for TokenAccount {
+    fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
+        StateWithExtensions::<spl_token_2022::state::Account>::unpack(buf)
+            .map(|t| TokenAccount(t.base))
+            .map_err(Into::into)
+    }
+}
+
+impl anchor_lang::AccountSerialize for TokenAccount {}
+
+impl anchor_lang::Owners for TokenAccount {
+    fn owners() -> &'static [Pubkey] {
+        &IDS
+    }
+}
+
+impl Deref for TokenAccount {
+    type Target = spl_token_2022::state::Account;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Copy)]
+pub struct Mint(spl_token_2022::state::Mint);
+
+impl anchor_lang::AccountDeserialize for Mint {
+    fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
+        StateWithExtensions::<spl_token_2022::state::Mint>::unpack(buf)
+            .map(|t| Mint(t.base))
+            .map_err(Into::into)
+    }
+}
+
+impl anchor_lang::AccountSerialize for Mint {}
+
+impl anchor_lang::Owners for Mint {
+    fn owners() -> &'static [Pubkey] {
+        &IDS
+    }
+}
+
+impl Deref for Mint {
+    type Target = spl_token_2022::state::Mint;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Clone)]
+pub struct TokenInterface;
+
+impl anchor_lang::Ids for TokenInterface {
+    fn ids() -> &'static [Pubkey] {
+        &IDS
+    }
+}
+
+pub type ExtensionsVec = Vec<ExtensionType>;
+
+pub fn find_mint_account_size(extensions: Option<&ExtensionsVec>) -> anchor_lang::Result<usize> {
+    if let Some(extensions) = extensions {
+        Ok(ExtensionType::get_account_len::<
+            spl_token_2022::state::Mint,
+        >(extensions))
+    } else {
+        Ok(spl_token_2022::state::Mint::LEN)
+    }
+}
+
+pub fn get_mint_extension_data<T: Extension + Pod>(
+    account: &solana_program::account_info::AccountInfo,
+) -> anchor_lang::Result<T> {
+    let mint_data = account.data.borrow();
+    let mint_with_extension =
+        StateWithExtensions::<spl_token_2022::state::Mint>::unpack(&mint_data)?;
+    let extension_data = *mint_with_extension.get_extension::<T>()?;
+    Ok(extension_data)
+}


### PR DESCRIPTION
- Add support for token 2022
- Only adds support for extensions that are relatively easy to add to our not up-to-date anchor fork
- We primarily  care about transfer hooks at this point in time